### PR TITLE
Add HanjaDataPipeline w/ util APIs, Hanja DTO

### DIFF
--- a/data/dtos.py
+++ b/data/dtos.py
@@ -1,12 +1,29 @@
-import io
+"""데이터 파이프라인에서 활용되는 DTO가 정의된 모듈입니다."""
 
+
+import io
 from dataclasses import dataclass
+
+from PIL import Image
 
 
 @dataclass
 class Artwork:
+    """작품 데이터를 담는 DTO입니다."""
+
     row_num: int
     artist_name: str
     artwork_name: str
     drive_url: str
     image_streams: list[dict[str, str | io.BytesIO]]
+
+
+@dataclass
+class Hanja:
+    """작품에서 추출된 한자 데이터를 담는 DTO입니다."""
+
+    hanja_character: str
+    huneum: str
+    image: Image
+    from_artwork: str
+    from_artist: str

--- a/data/hanja.py
+++ b/data/hanja.py
@@ -1,0 +1,66 @@
+"""한자 데이터 파이프라인의 구현체인 HanjaDataPipeline이 정의된 모듈입니다."""
+
+
+import logging
+from typing import NoReturn
+
+from PIL import Image
+
+from dtos import Artwork
+from dtos import Hanja
+from utils.image_module import recognize_optical_character, crop_image_to_box
+from utils.hanja_module import get_huneum
+
+
+class HanjaDataPipeline:
+    """작품 이미지에서 한자 데이터를 추출하여 적재하는 파이프라인입니다."""
+
+    def __init__(self, artworks: list[Artwork]) -> None:
+        self.artworks = artworks
+        self.hanjas = []  # list[Hanja]
+        self.tesseract_lang = 'chi_tra+chi_tra_vert+chi_sim+chi_sim_vert'
+
+    def activate_pipeline(self) -> NoReturn:
+        """한자 데이터 파이프라인을 가동하기 위한 트리거 API입니다.
+
+        API가 호출되면 아래 작업들이 순차적으로 실행됩니다.
+        1. 인스턴스 변수 `artworks`를 순회합니다.
+        2. 원소의 작품 이미지 리스트 `image_stream`을 순회합니다.
+        3. Hanja 인스턴스를 생성하여 하기 4, 5번의 정보를 담습니다.
+        4. 이미지를 전처리 한 후 OCR 모듈을 호출하여 한자 문자를 인식합니다.
+        5. 인식된 한자를 '훈음'으로 라벨링합니다.
+        6. Hanja 인스턴스를 파이프라인의 인스턴스 변수인 `hanjas`에 추가합니다.
+        7. `artworks`의 순회가 끝나면 `hanjas` 리스트를 순회합니다.
+        8. 원소의 이미지와 메티데이터를 GCS 버킷에 적재합니다.
+        9. 원소의 '훈음' 데이터를 Meilisearch에 적재합니다.
+
+        Args:
+            API 호출 시 지정할 수 있는 매개변수가 없습니다.
+
+        Returns:
+            API 호출 후 반환되는 값이 없습니다.
+        """
+
+        logging.info('Activate HanjaDataPipeline...')
+
+        for artwork in self.artworks:
+            for image_stream in artwork.image_streams:
+                image = Image.open(image_stream)
+                boxes = recognize_optical_character(image, self.tesseract_lang)
+
+                for box in boxes.splitlines():
+                    hanja_character, left, bottom, right, top, _ = box.split()
+                    coords = list(map(int, [left, bottom, right, top]))
+
+                    box_image = crop_image_to_box(image, coords)
+                    huneum = get_huneum(hanja_character)
+
+                    self.hanjas.append(Hanja(
+                        hanja_character=hanja_character,
+                        huneum=huneum,
+                        image=box_image,
+                        from_artwork=artwork.artwork_name,
+                        from_artist=artwork.artist_name
+                    ))
+
+        # TODO: 로직 구현 (Upload hanjas to GCS, Meilisearch)

--- a/data/utils/hanja_module.py
+++ b/data/utils/hanja_module.py
@@ -1,0 +1,16 @@
+"""한자 문자를 처리하는 다양한 API들이 정의된 모듈입니다."""
+
+
+def get_huneum(hanja_character: str) -> str:
+    """입력된 한자 문자의 훈음을 식별하여 반환합니다.
+
+    TODO: 로직 구현 (현재 훈음이 아닌 입력값을 그대로 반환)
+
+    Args:
+        hanja_character: 훈음을 식별할 한자 문자입니다.
+
+    Returns:
+        입력값으로 들어온 한자 문자의 훈음을 str 타입으로 반환합니다.
+    """
+
+    return hanja_character

--- a/data/utils/image_module.py
+++ b/data/utils/image_module.py
@@ -45,3 +45,19 @@ def recognize_optical_character(image: Image, lang: str) -> str:
     boxes = pytesseract.image_to_boxes(preprocessed_image, lang=lang)
 
     return boxes
+
+
+def crop_image_to_box(image: Image, coords: list[int]) -> Image:
+    """주어진 좌표를 활용하여 이미지를 Box 형태로 편집하여 반환합니다.
+
+    TODO: 로직 구현 (현재는 원본 이미지를 그대로 반환)
+
+    Args:
+        image: 편집할 원본 이미지입니다.
+        coords: Box 이미지를 만들 때 사용하는 좌표값입니다.
+
+    Returns:
+        원본 이미지를 좌표값을 기준으로 편집한 이미지입니다.
+    """
+
+    return image


### PR DESCRIPTION
- 한자 데이터 적재 파이프라인의 구현체인 `HanjaDataPipeline`의 기초 인터페이스를 구현하였습니다.
  - `activate_pipeline()`: 파이프라인을 가동하기 위한 진입점 API입니다.
    - 작품 이미지를 OCR하여 한자를 분리
      - `recognize_optical_character()`: 이미지 전처리 및 OCR
      - `data.utils.image_module.crop_image_to_box()`: 이미지에서 한자 부분을 추출하기 위한 이미지 편집용 API
    - 분리된 한자에 대한 훈음을 식별 `data.utils.get_huneum()`
    - Hanja 인스턴스 생성
- `Hanja` DTO를 추가하였습니다.
  - 누락된 Docstring을 추가하였습니다.