### PR TITLE
Add search func in meili customize, Add search test

### DIFF
--- a/search_engine/meili_customize/search.py
+++ b/search_engine/meili_customize/search.py
@@ -1,0 +1,87 @@
+from .config import Config
+
+
+class Search:
+    """Meilisearch 기반 검색엔진
+
+    실시간 사용자 입력 기반 추천 검색 리스트 5개와
+    사용자 입력 문자열 기반 검색 정보를 제공합니다.
+
+    search:
+        Description:
+            사용자가 입력한 문자열 'chi'와 's_val' 기준으로 필터링된 정보를 반환합니다.
+
+    suggest:
+        Description:
+            사용자가 실시간으로 입력한 문자열 'chi'기반으로 실시간 추천 검색 리스트 5개를 반환합니다.
+    """
+
+    def __init__(self, config: Config):
+        self.config = config
+        self.five_style = ['jeonseo', 'yeseo', 'haeseo', 'haengseo', 'choseo']
+
+    def search(self, chi: str, s_val: str = 'jeonseo') -> list[dict]:
+        """사용자가 입력한 문자열 'chi'와 's_val' 기준으로 필터링된 정보를 반환합니다.
+
+        문자열 'chi'와 원하는 오서 중 한개인 's_val'을 매개변수로 입력받을 경우
+        필터링된 검색 정보를 반환합니다.
+
+        Args:
+            chi: str ['한자', '훈', '음', '훈 음' 모두 검색 가능 (예: '月 달 월')]
+            s_val: str [오서('jeonseo', 'yeseo', 'haeseo', 'haengseo', 'choseo') 중 한개를 입력하며, 기본값은 'jeonseo'입니다.]
+
+        Raises:
+            ValueError: 인자가 조건에 맞지 않는 경우
+
+        Returns:
+            hits: 검색 조건에 맞는 한자 문서를 반환
+        """
+
+        if s_val not in self.five_style:
+            raise Exception(
+                '오서("jeonseo", "yeseo", "haeseo", "haengseo", "choseo") 중 한개를 입력해주세요.')
+        if not chi and isinstance(chi, str):
+            raise Exception('알맞은 검색어로 검색해주세요.')
+
+        filter_str = f'style = "{s_val}"'
+        results = self.config.index.search(
+            chi,
+            {
+                'filter': [filter_str]
+            }
+        )
+        return results
+
+    def suggest(self, chi: str, s_val: str = 'jeonseo') -> list[dict]:
+        """사용자가 실시간으로 입력한 문자열 'chi'기반으로 실시간 추천 검색 리스트 5개를 반환합니다.
+
+        사용자가 문자열을 입력할 경우, 입력한 문자(or문자열)이 실시간으로 매개변수 'chi'로 요청하여,
+        상위 5개의 hits값을 반환합니다.
+
+        Args:
+            chi: str ['한자', '훈', '음', '훈 음' 모두 검색 가능 (예: '月 달 월')]
+            s_val: str [오서('jeonseo', 'yeseo', 'haeseo', 'haengseo', 'choseo') 중 한개를 입력하며, 기본값은 'jeonseo'입니다.]
+
+        Raises:
+            ValueError: 인자가 조건에 맞지 않는 경우
+
+        Returns:
+            hits: 검색 조건에 맞는 한자 리스트를 반환
+        """
+
+        if s_val not in self.five_style:
+            raise Exception(
+                '오서("jeonseo", "yeseo", "haeseo", "haengseo", "choseo") 중 한개를 입력해주세요.')
+        if not chi and isinstance(chi, str):
+            raise Exception('알맞은 검색어로 검색해주세요.')
+
+        filter_str = f"style = '{s_val}'"
+        results = self.config.index.search(
+            chi,
+            {
+                'filter': [filter_str],
+                'limit': 5
+            }
+        )
+        suggestions = [hit['character'] for hit in results['hits']]
+        return suggestions

--- a/search_engine/tests/test_search.py
+++ b/search_engine/tests/test_search.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import patch, Mock
+
+from search_engine.meili_customize.search import Search
+
+
+class TestSearchMock(unittest.TestCase):
+
+    @patch('search_engine.meili_customize.config.Config')
+    def setUp(self, MockConfig):
+        """메일리서치 API 통신을 임의의 가짜(Mock)로 대체합니다."""
+        self.mock_config = MockConfig()
+        self.mock_index = Mock()
+        self.mock_config.index = self.mock_index
+        self.search_instance = Search(self.mock_config)
+
+    def test_search(self):
+        """검색 테스트"""
+        mock_results = {
+            'estimatedTotalHits': 1,
+            'hits': [{'id': 12, 'character': '火 불 화', 'style': 'yeseo'}],
+            'limit': 20, 'offset': 0, 'processingTimeMs': 0, 'query': '불'}
+
+        self.mock_index.search.return_value = mock_results
+        result = self.search_instance.search('불', 'yeseo')
+
+        # 검색 결과가 잘 나오는지 확인
+        self.assertEqual(result, mock_results)
+
+        # index.search() 메서드의 인자값으로 아래와 같이 요청이 되었는지 확인
+        self.mock_index.search.assert_called_once_with(
+            '불', {'filter': ['style = "yeseo"']})
+
+    def test_suggest(self):
+        """추천 검색어 리스트 테스트"""
+        mock_suggestions = {
+            'hits': [
+                {
+                    'id': 7,
+                    'character': '月 달 월',
+                    'style': 'yeseo'
+                },
+                {
+                    'id': 2,
+                    'character': '日 날 일',
+                    'style': 'yeseo'
+                }
+            ],
+            'query': '달',
+            'processingTimeMs': 367,
+            'limit': 5,
+            'offset': 0,
+            'estimatedTotalHits': 2
+        }
+        self.mock_index.search.return_value = mock_suggestions
+
+        suggestions = self.search_instance.suggest('달', 'yeseo')
+        expected_suggestions = ['月 달 월', '日 날 일']
+
+        # 문자('달') 기반으로 추천 리스트 확인
+        self.assertEqual(suggestions, expected_suggestions)
+
+        # index.search() 메서드의 인자값으로 아래와 같이 요청이 되었는지 확인
+        self.mock_index.search.assert_called_once_with(
+            '달', {'filter': ["style = 'yeseo'"], 'limit': 5})


### PR DESCRIPTION
#### 메일리서치 검색, 실시간 추천 검색 기능 추가

  - Search class
    - search: 문자(열)와 오서 기반으로 검색 결과 반환
    - suggest: 문자(열)와 오서 기반으로 추천 한자(훈, 음) 리스트 최대 5개 반환


#### 메일리서치 검색, 실시간 추천 검색 기능 로직 테스트 코드 추가

  - test_search: 검색 결괏값과 'search' 인자값 호출이 한 번 되었는지 확인
  - test_suggest: 검색 결괏값과 'search' 인자값 호출이 한 번 되었는지 확인
  - 두 테스트의 차이점
    - search: 문서 기반의 검색 결괏값이 잘 나오는지, Meilisearch.search 메서드의 인자값 확인 (문자, 필터 필드값)
    -  suggest: 추천 검색어 리스트이기 때문에 문자열 리스트가 잘 반환되는지, `search` 인자값에서 limit 필드값이 잘 추가되었는지 확인