### PR TITLE
한자 데이터 적재 로직 추가 (GCS)

### DIFF
--- a/data/client/google_client.py
+++ b/data/client/google_client.py
@@ -1,0 +1,35 @@
+import io
+from typing import NoReturn
+
+from google.oauth2.service_account import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaIoBaseUpload
+
+
+class StorageClient:
+    def __init__(self):
+        self.creds = Credentials.from_service_account_file(
+            'service_account_key.json')
+        self.storage_service = build('storage', 'v1', credentials=self.creds)
+
+    def insert_bytes_object_into_bucket(
+        self,
+        fd: io.BytesIO,
+        mimitype: str,
+        bucket: str,
+        file_name: str
+    ) -> NoReturn:
+        """Bytes 오브젝트를 GCS 버킷에 적재합니다."""
+
+        media = MediaIoBaseUpload(
+            fd,
+            mimetype=mimitype,
+        )
+
+        self.storage_service.objects().insert(  # pylint: disable=no-member
+            bucket=bucket,
+            media_body=media,
+            body={
+                'name': file_name
+            }
+        ).execute()

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -20,6 +20,7 @@ pyasn1_modules==0.4.1
 pyparsing==3.2.0
 pytesseract==0.3.13
 pytest==8.3.3
+pytest-mock==3.14.0
 python-dotenv==1.0.1
 requests==2.32.3
 rsa==4.9

--- a/data/tests/client/test_google_client.py
+++ b/data/tests/client/test_google_client.py
@@ -1,0 +1,32 @@
+import io
+import pytest
+
+from data.client.google_client import StorageClient
+
+
+@pytest.fixture(scope='module')  # 'data.tests.client.test_google_client'
+def storage_client():
+    return StorageClient()
+
+
+def test_insert_bytes_object_into_bucket(mocker, storage_client):  # pylint: disable=redefined-outer-name
+    fd = io.BytesIO(b'Dummy WEBP image data for test')
+    mimetype = 'image/webp'
+    bucket = 'dummy_bucket'
+    file_name = 'dummy_image.webp'
+
+    mock_objects = mocker.Mock()
+    mock_storage_service = mocker.Mock()
+
+    mock_storage_service.objects.return_value = mock_objects
+    storage_client.storage_service = mock_storage_service
+
+    storage_client.insert_bytes_object_into_bucket(
+        fd, mimetype, bucket, file_name)
+
+    mock_storage_service.objects.assert_called_once()
+    mock_objects.insert.assert_called_once_with(
+        bucket=bucket,
+        media_body=mocker.ANY,
+        body={'name': file_name}
+    )


### PR DESCRIPTION
한자 데이터(Hanja)를 GCS 버킷에 적재하는 로직을 추가하였습니다.

- API mocking을 위한 pytest-mock 라이브러리 설치
- GCS Bucket API를 추상화한 인터페이스인 StorageClient 구현
- Hanja를 파싱하여 버킷에 적재하는 로직 구현 (`upload_hanja_to_bucket`)
  - 로직 내부에서 StorageClient 인스턴스 사용 (`StorageClient.insert_bytes_object_into_bucket`)
  - 적재 로직 변경: 한자 이미지 분리 직후 개별 업로드
    - 이전 방식: 모든 한자 이미지 분리 후, 분리된 이미지를 모두 모아서 업로드
