### PR TITLE
Spring Boot관련 gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,24 @@ service_account_key*.json
 
 # Logs
 *.log
+
+### Spring Boot ###
+HELP.md
+
+### Java ###
+*.class
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+### Gradle ###
+.gradle
+build/
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache


### PR DESCRIPTION
## DESCRIPTION

Related #122 

`.gradle/`, `build/` 디렉토리를 git에서 제외합니다.

## TODO

- .gitignore에 Spring Boot 관련 특정 파일 및 디렉토리 추가