### PR TITLE
123 작품 이미지 조회 api 설계 및 개발 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# SQLite3
-*.sqlite3
-*.db
-
 # macOS
 .DS_Store
 .localized

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.1'
-	id 'io.spring.dependency-management' version '1.1.6'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 jar {
@@ -24,6 +24,9 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.meilisearch.sdk:meilisearch-java:0.14.2'
+	// gcs
+	implementation 'org.springframework.cloud:spring-cloud-gcp-starter:1.2.8.RELEASE'
+	implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.8.RELEASE'
 	compileOnly 'org.projectlombok:lombok:1.18.36'
 	annotationProcessor 'org.projectlombok:lombok:1.18.36'
 	// postgres, not jdbc and jpa

--- a/backend/src/main/java/com/cali/controller/SearchController.java
+++ b/backend/src/main/java/com/cali/controller/SearchController.java
@@ -1,13 +1,12 @@
 package com.cali.controller;
 
 import org.springframework.web.bind.annotation.RestController;
-
 import com.cali.service.SearchServiceImpl;
-
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,12 +15,17 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
 public class SearchController {
-
     private final SearchServiceImpl searchService;
 
     @GetMapping("/search")
     public List<String> getSearchResult(@RequestParam(value = "q") String query) {
         return searchService.getSearchResult(query);
+    }
+
+    @GetMapping(value = "/images")
+    public ResponseEntity<String> getHanjaImage(@RequestParam(value = "q") String query,
+            @RequestParam(value = "s") String style) {
+        return searchService.getHanjaImage(query, style);
     }
 
 }

--- a/backend/src/main/java/com/cali/gcp/GcsClient.java
+++ b/backend/src/main/java/com/cali/gcp/GcsClient.java
@@ -1,0 +1,32 @@
+package com.cali.gcp;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class GcsClient {
+
+    private static Storage storage;
+
+    public static Storage getGcsStorage() throws IOException {
+        String keyFileName = System.getenv("SERVICE_ACCOUNT_KEY_NAME");
+        if (keyFileName == null || keyFileName.isEmpty()) {
+            throw new RuntimeException("Environment variable SERVICE_ACCOUNT_KEY_NAME is not set or empty");
+        }
+
+        InputStream credentialsStream = GcsClient.class.getResourceAsStream("/" + keyFileName + ".json");
+        if (credentialsStream == null) {
+            throw new RuntimeException("Service account key not found in classpath: " + keyFileName);
+        }
+
+        GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
+        storage = StorageOptions.newBuilder()
+                .setCredentials(credentials)
+                .build()
+                .getService();
+        return storage;
+    }
+}

--- a/backend/src/main/java/com/cali/meilisearch/MeilisearchService.java
+++ b/backend/src/main/java/com/cali/meilisearch/MeilisearchService.java
@@ -19,7 +19,7 @@ public class MeilisearchService {
     private final Client meilisearchClient;
 
     public ArrayList<HashMap<String, Object>> search(String query) throws MeilisearchApiException {
-        Index index = meilisearchClient.getIndex("chi");
+        Index index = meilisearchClient.getIndex("hanja");
         return index.search(new SearchRequest(query)
                 .setLimit(5)).getHits();
     }

--- a/backend/src/main/java/com/cali/service/SearchService.java
+++ b/backend/src/main/java/com/cali/service/SearchService.java
@@ -2,7 +2,12 @@ package com.cali.service;
 
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
+
 public interface SearchService {
 
     public List<String> getSearchResult(String query);
+
+    public ResponseEntity<String> getHanjaImage(String query, String style);
+
 }

--- a/backend/src/main/java/com/cali/service/SearchServiceImpl.java
+++ b/backend/src/main/java/com/cali/service/SearchServiceImpl.java
@@ -1,12 +1,19 @@
 package com.cali.service;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import com.cali.gcp.GcsClient;
 import com.cali.meilisearch.MeilisearchService;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
 import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 
 import lombok.RequiredArgsConstructor;
@@ -14,20 +21,49 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class SearchServiceImpl implements SearchService {
-
     private final MeilisearchService meilisearchService;
 
     @Override
     public List<String> getSearchResult(String query) {
-
         List<String> searchResult = new ArrayList<String>();
         try {
             searchResult = meilisearchService.search(query).stream()
                     .map(result -> result.get("hanja_hun_eum").toString())
                     .collect(Collectors.toList());
         } catch (MeilisearchApiException e) {
-            System.err.printf("meilisearch api exception!\n%s", e.toString());
+            System.err.printf("Meilisearch API exception!\n%s", e.toString());
         }
         return searchResult;
     }
+
+    @Override
+    public ResponseEntity<String> getHanjaImage(String query, String style) {
+        List<String> images = new ArrayList<>();
+
+        try {
+            Storage storage = GcsClient.getGcsStorage();
+            String bucketName = System.getenv("HANJA_BUCKET");
+            // query: 環 고리 환
+            String[] parts = query.split(" ");
+            String folderPath = parts[1] + "/" + parts[2] + "/" + style;
+
+            Iterable<Blob> blobs = storage.list(bucketName).iterateAll();
+            for (Blob blob : blobs) {
+                if (blob.getName().startsWith(folderPath) && blob.getName().endsWith(".webp")) {
+                    byte[] imageBytes = blob.getContent();
+                    String base64Image = Base64.getEncoder().encodeToString(imageBytes);
+                    images.add("<img src='data:image/jpeg;base64," + base64Image + "' alt='" + blob.getName() + "'/>");
+                }
+            }
+        } catch (IOException e) {
+            System.err.printf("GCS bucket API exception!\n%s", e.toString());
+        }
+
+        if (images.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+        String htmlResponse = "<html><body>" + String.join("<br/>", images) + "</body></html>";
+        return ResponseEntity.ok().body(htmlResponse);
+    }
+
 }


### PR DESCRIPTION
Related #123 

## DESCRIPTION

특정 한자에 대한 작품 이미지를 조회할 수 있는 API입니다.

## TODO

- API 설계 및 개발
  - 추천 리스트 5개 중 1개를 선택했을 경우, 선택된 한자 기준으로 이미지를 제공하는 API입니다.
  - 훈 -> 음 -> 오서(전서, 예서 등) 순서로 폴더 경로의 모든 이미지를 가져와서 클라이언트에 제공합니다.
  - 이미지를 핸들링하는 HTML 하드코드가 있어, 추후 클라이언트에서 핸들링할 경우 수정이 필요합니다.

## API

- 추천 검색어 API
  - `http://localhost:8080/api/v1/search?q=고리`
- 이미지 API
  - `http://localhost:8080/api/v1/images?q=環 고리 환&s=예서`