### PR TITLE
Feature/artwork image api

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	// gcs
 	implementation 'org.springframework.cloud:spring-cloud-gcp-starter:1.2.8.RELEASE'
 	implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.8.RELEASE'
+	// validation
+	implementation 'jakarta.validation:jakarta.validation-api'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok:1.18.36'
 	annotationProcessor 'org.projectlombok:lombok:1.18.36'
 	// postgres, not jdbc and jpa

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,6 +24,9 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.meilisearch.sdk:meilisearch-java:0.14.2'
+	// gcs
+	implementation 'org.springframework.cloud:spring-cloud-gcp-starter:1.2.8.RELEASE'
+	implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.8.RELEASE'
 	compileOnly 'org.projectlombok:lombok:1.18.36'
 	annotationProcessor 'org.projectlombok:lombok:1.18.36'
 	// postgres, not jdbc and jpa

--- a/backend/src/main/java/com/cali/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/cali/controller/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.cali.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jakarta.validation.ConstraintViolationException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<?> handleConstraintViolation(ConstraintViolationException ex) {
+        return ResponseEntity.badRequest().body(ex.getMessage());
+    }
+}

--- a/backend/src/main/java/com/cali/controller/SearchController.java
+++ b/backend/src/main/java/com/cali/controller/SearchController.java
@@ -2,14 +2,16 @@ package com.cali.controller;
 
 import org.springframework.web.bind.annotation.RestController;
 
-import com.cali.repository.ImageResponse;
 import com.cali.service.SearchServiceImpl;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
+@Validated
 public class SearchController {
 
     private final SearchServiceImpl searchService;
@@ -27,8 +30,8 @@ public class SearchController {
     }
 
     @GetMapping(value = "/images")
-    public ResponseEntity<List<ImageResponse>> getHanjaImages(@RequestParam(value = "q") String query,
-            @RequestParam(value = "s") String style) {
+    public ResponseEntity<?> getHanjaImages(@Valid @RequestParam(value = "q") @NotBlank String query,
+            @Valid @RequestParam(value = "s") @NotBlank String style) {
         return ResponseEntity.ok().body(searchService.getHanjaImages(query, style));
     }
 

--- a/backend/src/main/java/com/cali/controller/SearchController.java
+++ b/backend/src/main/java/com/cali/controller/SearchController.java
@@ -2,12 +2,14 @@ package com.cali.controller;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import com.cali.repository.ImageResponse;
 import com.cali.service.SearchServiceImpl;
 
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,6 +24,12 @@ public class SearchController {
     @GetMapping("/search")
     public List<String> getSearchResult(@RequestParam(value = "q") String query) {
         return searchService.getSearchResult(query);
+    }
+
+    @GetMapping(value = "/images")
+    public ResponseEntity<List<ImageResponse>> getHanjaImages(@RequestParam(value = "q") String query,
+            @RequestParam(value = "s") String style) {
+        return ResponseEntity.ok().body(searchService.getHanjaImages(query, style));
     }
 
 }

--- a/backend/src/main/java/com/cali/gcp/GcsClientFactory.java
+++ b/backend/src/main/java/com/cali/gcp/GcsClientFactory.java
@@ -1,0 +1,34 @@
+package com.cali.gcp;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GcsClientFactory {
+
+    @Bean
+    public Storage GcsClient() throws IOException {
+        String keyFileName = System.getenv("SERVICE_ACCOUNT_KEY_NAME");
+        if (keyFileName == null || keyFileName.isEmpty()) {
+            throw new RuntimeException("Environment variable SERVICE_ACCOUNT_KEY_NAME is not set or empty");
+        }
+
+        InputStream credentialsStream = GcsClientFactory.class.getResourceAsStream("/" + keyFileName + ".json");
+        if (credentialsStream == null) {
+            throw new RuntimeException("Service account key not found in classpath: " + keyFileName);
+        }
+
+        GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
+        return StorageOptions.newBuilder()
+                .setCredentials(credentials)
+                .build()
+                .getService();
+    }
+}

--- a/backend/src/main/java/com/cali/gcp/GcsService.java
+++ b/backend/src/main/java/com/cali/gcp/GcsService.java
@@ -1,0 +1,45 @@
+package com.cali.gcp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.cali.repository.ImageResponse;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Blob;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GcsService {
+
+    private final Storage gcsClient;
+
+    public List<ImageResponse> getImages(String bucketName, String folderPath) {
+        List<ImageResponse> images = new ArrayList<>();
+
+        Iterable<Blob> blobs = gcsClient.list(bucketName).iterateAll();
+        for (Blob blob : blobs) {
+            if (blob.getName().startsWith(folderPath) && blob.getName().endsWith(".webp")) {
+                byte[] imageBytes = blob.getContent();
+
+                String imageString = blob.getName();
+                String lastSegment = imageString.substring(imageString.lastIndexOf("/") + 1);
+
+                String[] artistArtwork = lastSegment.split("_");
+                String artist = artistArtwork[0];
+                String artwork = artistArtwork[1];
+
+                ImageResponse imageResponse = new ImageResponse();
+                imageResponse.setArtist(artist);
+                imageResponse.setArtwork(artwork);
+                imageResponse.setImage(imageBytes);
+                images.add(imageResponse);
+            }
+        }
+        return images;
+    }
+
+}

--- a/backend/src/main/java/com/cali/gcp/GcsService.java
+++ b/backend/src/main/java/com/cali/gcp/GcsService.java
@@ -17,7 +17,8 @@ public class GcsService {
 
     private final Storage gcsClient;
 
-    public List<ImageResponse> getImages(String bucketName, String folderPath) {
+    public List<ImageResponse> getImages(String folderPath) {
+        String bucketName = System.getenv("HANJA_BUCKET");
         List<ImageResponse> images = new ArrayList<>();
 
         Iterable<Blob> blobs = gcsClient.list(bucketName).iterateAll();

--- a/backend/src/main/java/com/cali/meilisearch/MeilisearchService.java
+++ b/backend/src/main/java/com/cali/meilisearch/MeilisearchService.java
@@ -19,7 +19,7 @@ public class MeilisearchService {
     private final Client meilisearchClient;
 
     public ArrayList<HashMap<String, Object>> search(String query) throws MeilisearchApiException {
-        Index index = meilisearchClient.getIndex("chi");
+        Index index = meilisearchClient.getIndex("hanja");
         return index.search(new SearchRequest(query)
                 .setLimit(5)).getHits();
     }

--- a/backend/src/main/java/com/cali/repository/ImageResponse.java
+++ b/backend/src/main/java/com/cali/repository/ImageResponse.java
@@ -1,0 +1,12 @@
+package com.cali.repository;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ImageResponse {
+    private String artist;
+    private String artwork;
+    private byte[] image;
+}

--- a/backend/src/main/java/com/cali/service/SearchService.java
+++ b/backend/src/main/java/com/cali/service/SearchService.java
@@ -2,7 +2,11 @@ package com.cali.service;
 
 import java.util.List;
 
+import com.cali.repository.ImageResponse;
+
 public interface SearchService {
 
     public List<String> getSearchResult(String query);
+
+    public List<ImageResponse> getHanjaImages(String query, String style);
 }

--- a/backend/src/main/java/com/cali/service/SearchServiceImpl.java
+++ b/backend/src/main/java/com/cali/service/SearchServiceImpl.java
@@ -6,7 +6,9 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.cali.gcp.GcsService;
 import com.cali.meilisearch.MeilisearchService;
+import com.cali.repository.ImageResponse;
 import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 
 import lombok.RequiredArgsConstructor;
@@ -16,10 +18,10 @@ import lombok.RequiredArgsConstructor;
 public class SearchServiceImpl implements SearchService {
 
     private final MeilisearchService meilisearchService;
+    private final GcsService gcsService;
 
     @Override
     public List<String> getSearchResult(String query) {
-
         List<String> searchResult = new ArrayList<String>();
         try {
             searchResult = meilisearchService.search(query).stream()
@@ -30,4 +32,15 @@ public class SearchServiceImpl implements SearchService {
         }
         return searchResult;
     }
+
+    @Override
+    public List<ImageResponse> getHanjaImages(String query, String style) {
+        String bucketName = System.getenv("HANJA_BUCKET");
+
+        String[] parts = query.split(" ");
+        String folderPath = parts[1] + "/" + parts[2] + "/" + style;
+
+        return gcsService.getImages(bucketName, folderPath);
+    }
+
 }

--- a/backend/src/main/java/com/cali/service/SearchServiceImpl.java
+++ b/backend/src/main/java/com/cali/service/SearchServiceImpl.java
@@ -35,12 +35,10 @@ public class SearchServiceImpl implements SearchService {
 
     @Override
     public List<ImageResponse> getHanjaImages(String query, String style) {
-        String bucketName = System.getenv("HANJA_BUCKET");
-
         String[] parts = query.split(" ");
         String folderPath = parts[1] + "/" + parts[2] + "/" + style;
 
-        return gcsService.getImages(bucketName, folderPath);
+        return gcsService.getImages(folderPath);
     }
 
 }


### PR DESCRIPTION
## DESCRIPTION

특정 한자에 대한 작품 이미지를 조회할 수 있는 API입니다. #123 

## TODO

- API 설계 및 개발
  - 추천 리스트 5개 중 1개를 선택했을 경우, 선택된 한자 기준으로 이미지를 제공하는 API입니다.
  - 훈 -> 음 -> 오서(전서, 예서 등) 순서로 폴더 경로의 모든 이미지를 가져와서 클라이언트에 제공합니다.

## API

- 이미지 API
  - `http://localhost:8080/api/v1/images?q=環 고리 환&s=예서`